### PR TITLE
Fixed Issue 13

### DIFF
--- a/app/controllers/timecard_entries_controller.rb
+++ b/app/controllers/timecard_entries_controller.rb
@@ -1,5 +1,6 @@
 class TimecardEntriesController < ApplicationController
 	before_filter :login_required
+  before_filter :unsubmitted_timecard?, :only=>[:new, :create]
 	layout 'application2'
 
 	def index
@@ -79,4 +80,13 @@ class TimecardEntriesController < ApplicationController
 		@timecard_entry.destroy
 		redirect_to :action => :index
 	end
+  private
+  def unsubmitted_timecard?
+    if Timecard.valid_timecards.empty?
+      flash[:error]="There are no active timecards"
+      redirect_to :action => :index and return
+    end
+  end
+
+
 end

--- a/app/views/timecard_entries/index.rhtml
+++ b/app/views/timecard_entries/index.rhtml
@@ -2,9 +2,11 @@
 <h1>Listing timecard entries</h1>
 <table class="eventsmain">
 <tr>
-<td style="padding: 0 20px 0 0;">
+  <td style="padding: 0 20px 0 0;">
+    <%if !Timecard.valid_timecards.empty? %>
 <p style="width: 175px;">Create a <%= link_to 'new timecard entry', new_timecard_entry_path %>.
 Once a timecard has been submitted, it can no longer be edited.</p>
+<% end %>
 <% unless @timecard_list.reject {|i| i.nil? or !i.submitted}.size == 0 %>
 <h3 style="width: 175px;">Past timecards</h3>
 <% end %>


### PR DESCRIPTION
- Added before_filter on new/create to check if any active timecards
  - Added check for active timecards when displaying create new entry blurb
