### PR TITLE
Remove blackout links on public calendar

### DIFF
--- a/app/views/events/_monthview.html.erb
+++ b/app/views/events/_monthview.html.erb
@@ -66,11 +66,7 @@
                     <br />
                   <% end %>
                   <% date[:events].each do |evtdate| %>
-                    <% if can? :read, Event %>                    
-                      <%= link_to evtdate.event.title + " - " + evtdate.description, evtdate.event %>
-                    <% else %>
-                      <%= "#{evtdate.event.title} - #{evtdate.description}" %>
-                    <% end %>
+                    <%= text_with_conditional_link_to evtdate.event.title + " - " + evtdate.description, evtdate.event, :read, Event %>
                     <span>&rarr; <%= evtdate.startdate.strftime("%I:%M %p") %> - <%= evtdate.enddate.strftime("%I:%M %p") %></span><br />
                   <% end %>
                 </span>

--- a/app/views/events/_monthview.html.erb
+++ b/app/views/events/_monthview.html.erb
@@ -57,9 +57,9 @@
                   <% if date[:blackout] %>
                     Blackout:
                     <% if not date[:blackout].title.blank? and not date[:blackout].event.blank? %>
-                      <%= link_to date[:blackout].event.title, date[:blackout].event %> - <%= date[:blackout].title %>
+                      <%= text_with_conditional_link_to date[:blackout].event.title, date[:blackout].event, :read, Event %> - <%= date[:blackout].title %>
                     <% elsif not date[:blackout].event.blank? %>
-                      <%= link_to date[:blackout].event.title, date[:blackout].event %>
+                      <%= text_with_conditional_link_to date[:blackout].event.title, date[:blackout].event, :read, Event %>
                     <% else %>
                       <%= date[:blackout].title %>
                     <% end %>


### PR DESCRIPTION
Just what it says on the tin.

Currently, the public (logged-out) calendar page mouseovers link to blackout events if a blackout is associated with an event.