### PR TITLE
Show an org's events in reverse chronological order.

### DIFF
--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 <p><b><%= @org.events.length %> Events:</b></p>
 <ul>
-  <% @org.events.each do |e| %>
+  <% @org.events.order(representative_date: :desc).each do |e| %>
     <li><%= link_to e.to_s, e %> - <%= e.representative_date.strftime("%D") %></li>
   <% end %>
 </ul>


### PR DESCRIPTION
Base this on the representative dates of the events, not just the (implicit) order the events were added to the database.