### PR TITLE
Bring attention to when call/strike dates differ from event date.

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -83,15 +83,31 @@ module EventsHelper
   
   def render_eventdate_call(ed)
     if ed.has_call?
-      ed.effective_call.strftime("%H:%M")
+      if ed.effective_call.to_date == ed.startdate.to_date
+        ed.effective_call.strftime("%H:%M")
+      else
+        ed.effective_call.strftime("%H:%M <em>(%b %d)</em>").html_safe
+      end
     elsif ed.calltype == "blank"
       "<span class='unknown'>unknown</span>".html_safe
+    end
+  end
+
+  def render_eventdate_event(ed)
+    if ed.enddate.to_date == ed.startdate.to_date or ed.enddate - ed.startdate < 6.hours
+      "#{ed.startdate.strftime('%H:%M')} - #{ed.enddate.strftime('%H:%M')}"
+    else
+      "#{ed.startdate.strftime('%H:%M')} - #{ed.enddate.strftime('%H:%M <em>(%b %d)</em>')}".html_safe
     end
   end
   
   def render_eventdate_strike(ed)
     if ed.has_strike?
-      ed.effective_strike.strftime("%H:%M")
+      if ed.effective_strike.to_date == ed.startdate.to_date or ed.effective_strike - ed.startdate < 6.hours
+        ed.effective_strike.strftime("%H:%M")
+      else
+        ed.effective_strike.strftime("%H:%M <em>(%b %d)</em>").html_safe
+      end
     elsif ed.striketype == "blank"
       "<span class='unknown'>unknown</span>".html_safe
     elsif ed.striketype == "none"

--- a/app/views/events/_run.html.erb
+++ b/app/views/events/_run.html.erb
@@ -34,7 +34,7 @@
     <td>
       <small>
         C: <%= render_eventdate_call eventdate %><br/>
-        E: <%= eventdate.startdate.strftime("%H:%M") %> - <%= eventdate.enddate.strftime("%H:%M") %><br/>
+        E: <%= render_eventdate_event eventdate %><br/>
         S: <%= render_eventdate_strike eventdate %>
       </small>
     </td>


### PR DESCRIPTION
On the main events list page, add additional data under "Timing" to bring attention to "event dates" with elements that span multiple calendar days, whether intentionally or accidentally.  In particular, since the "Date" column shows the calendar date for event start, this is important if call, event end, and/or strike are on a different calendar day.

There is an exception for event end and strike in the typical edge case of a several-hour event running somewhat past midnight, in which case the intent is relatively straightforward without the extra notation.  For longer events, it is probably more helpful to include anyway.