### PR TITLE
Fix weekification of events that started in the past.

### DIFF
--- a/app/models/eventdate.rb
+++ b/app/models/eventdate.rb
@@ -166,7 +166,11 @@ class Eventdate < ApplicationRecord
 
   def self.weekify(eventdates)
     eventdates.chunk do |ed|
-      TimeDifference.between(DateTime.now.beginning_of_week, ed.startdate).in_weeks.floor
+      if ed.startdate < DateTime.now.beginning_of_week
+        0
+      else
+        TimeDifference.between(DateTime.now.beginning_of_week, ed.startdate).in_weeks.floor
+      end
     end.map do |weeks, eds|
       {
         :weeks_away => weeks,


### PR DESCRIPTION
Since TimeDifference provides the unsigned absolute value of the time difference, this was causing long-running events that had started, e.g., 2.xx weeks in the past to be weekified alongside events that had yet to start 2.xx weeks in the future.

Thanks to @auy86 for the report.
