### PR TITLE
Fix rendering of bottom border of merged eventrole

### DIFF
--- a/app/views/events/_run.html.erb
+++ b/app/views/events/_run.html.erb
@@ -61,6 +61,8 @@
         <% end %>
       <% end %>
       </td>
+    <% else %>
+      <td>&nbsp;</td>
     <% end %>
   </tr>
 <% end %>


### PR DESCRIPTION
Currently merged rows don't put any `td` when the event roles have already been printed, which results in this UI quirk. This should fix it

<img width="153" alt="Screen Shot 2021-08-11 at 10 49 20" src="https://user-images.githubusercontent.com/1385975/129051439-f8a94c6a-d7b0-45aa-b22c-6bfa772d0d41.png">
