### PR TITLE
Open Members link in a new tab

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -4,7 +4,8 @@ class MembersController < ApplicationController
   def index
     @title = "Member List"
     @order = Member.new.has_attribute?(params[:order]) ? params[:order] : Member::Default_sort_key
-    
+    @members_link = "https://www.abtech.org/wiki/bin/view/Main/WebHome?topic=PhoneList"
+
     if params[:desc] == "1"
       @members = @members.order(@order => :desc)
       @order_desc = true

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,5 +1,5 @@
   <h1>Members of AB Tech</h1>
-  <p>See also: <a href="https://www.abtech.org/wiki/bin/view/Main/WebHome?topic=PhoneList">https://www.abtech.org/wiki/bin/view/Main/WebHome?topic=PhoneList</a></p>
+  <p>See also: <%= link_to 'https://www.abtech.org/wiki/bin/view/Main/WebHome?topic=PhoneList', @members_link, :target=>"_blank" if not kiosk_signed_in? %><% if kiosk_signed_in? %>open this page on another device<% end %>.</p>
 <table class="generic" width="100%">
   <tr>
     <th><%=   table_order_link "kerbid",              "email",                  @order, @order_desc, @query %></th>


### PR DESCRIPTION
Opens the link to Members in a new tab to be consistent with how the weather link opens. 

Closes #505. 