### PR TITLE
Add :blob-emotes:

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,3 +18,4 @@
 //= require moment.min
 //= require fullcalendar.min
 //= require jquery.multi-select
+//= require emotes

--- a/vendor/assets/javascripts/emotes.js
+++ b/vendor/assets/javascripts/emotes.js
@@ -1,4 +1,13 @@
-let emoticons = {
+/* Adds selected emotes to all pages.
+ * Allows copy-paste to/from ABTech Slack
+ *
+ * Usage:
+ * -----
+ * Just use the emotes in any text :blobeyes:
+ */
+
+
+let emotes = {
     ':party-blob:': 'https://emojis.slackmojis.com/emojis/images/1643514770/7808/party-blob.gif?1643514770',
     ':blobsob:': 'https://emojis.slackmojis.com/emojis/images/1643514690/6921/blob_sob.png?1643514690',
     ':blobtoiletspin:': 'https://github.com/thomplinds/custom-slack-emojis/blob/main/images/blobtoiletflush.gif?raw=true',
@@ -11,24 +20,22 @@ let emoticons = {
 };
 
 $(function() {
-    // For each emote,
-    for (const [text, url] of Object.entries(emoticons)) {
-        // Find nodes with it
-        let text_nodes = $(`:contains("${text}")`).contents();
+    for (const [emote_text, url] of Object.entries(emotes)) {
+        let text_nodes = $(`:contains("${emote_text}")`).contents();
 
         // Filter to text (type 3) nodes that definitely contain it
         // (:contains doesn't guarantee this: https://stackoverflow.com/a/29418265)
         text_nodes = text_nodes.filter(function() {
-            return this.nodeType === 3 && this.textContent.indexOf(text) > -1;
+            return this.nodeType === 3 && this.textContent.indexOf(emote_text) > -1;
         });
 
         // replace the emote text with the img
         text_nodes.replaceWith(function() {
-            return this.nodeValue.replace(RegExp(text, "g"),
+            return this.nodeValue.replace(RegExp(emote_text, "g"),
                 // .emote-inline doesn't actually do anything
                 // height should end up roughly true line height
                 // alt text shows if image is not found and allows copy-paste
-                `<img class="emote-inline" style="height:1.4em; margin-bottom:-0.2em;" src="${url}" alt="${text}"/>`
+                `<img class="emote-inline" style="height:1.4em; margin-bottom:-0.2em;" src="${url}" alt="${emote_text}"/>`
             );
         });
     }

--- a/vendor/assets/javascripts/emotes.js
+++ b/vendor/assets/javascripts/emotes.js
@@ -1,5 +1,5 @@
 /* Adds selected emotes to all pages.
- * Allows copy-paste to/from ABTech Slack
+ * Allows copy-paste from ABTech Slack
  *
  * Usage:
  * -----

--- a/vendor/assets/javascripts/emotes.js
+++ b/vendor/assets/javascripts/emotes.js
@@ -1,0 +1,35 @@
+let emoticons = {
+    ':party-blob:': 'https://emojis.slackmojis.com/emojis/images/1643514770/7808/party-blob.gif?1643514770',
+    ':blobsob:': 'https://emojis.slackmojis.com/emojis/images/1643514690/6921/blob_sob.png?1643514690',
+    ':blobtoiletspin:': 'https://github.com/thomplinds/custom-slack-emojis/blob/main/images/blobtoiletflush.gif?raw=true',
+    ':blobsad:': 'https://emojis.slackmojis.com/emojis/images/1643514688/6904/blob_sad.png?1643514688',
+    ':blob-spin:': 'https://emojis.slackmojis.com/emojis/images/1643515247/12652/blobspin.png?1643515247',
+    ':blob-go:': 'https://emojis.slackmojis.com/emojis/images/1643514683/6858/blob_go.png?1643514683',
+    ':blob_excited:': 'https://emojis.slackmojis.com/emojis/images/1643514936/9579/blob_excited.gif?1643514936',
+    ':blobeyes:': 'https://emojis.slackmojis.com/emojis/images/1643514682/6848/blob_eyes.png?1643514682',
+    ':blobfearful:': 'https://emojis.slackmojis.com/emojis/images/1643514682/6850/blob_fearful.png?1643514682',
+};
+
+$(function() {
+    // For each emote,
+    for (const [text, url] of Object.entries(emoticons)) {
+        // Find nodes with it
+        let text_nodes = $(`:contains("${text}")`).contents();
+
+        // Filter to text (type 3) nodes that definitely contain it
+        // (:contains doesn't guarantee this: https://stackoverflow.com/a/29418265)
+        text_nodes = text_nodes.filter(function() {
+            return this.nodeType === 3 && this.textContent.indexOf(text) > -1;
+        });
+
+        // replace the emote text with the img
+        text_nodes.replaceWith(function() {
+            return this.nodeValue.replace(RegExp(text, "g"),
+                // .emote-inline doesn't actually do anything
+                // height should end up roughly true line height
+                // alt text shows if image is not found and allows copy-paste
+                `<img class="emote-inline" style="height:1.4em; margin-bottom:-0.2em;" src="${url}" alt="${text}"/>`
+            );
+        });
+    }
+})


### PR DESCRIPTION
![:party-blob: demo](https://github.com/ABTech/tracker/assets/66567994/b0fa3b2f-87f6-4772-a21b-559e04a79101)

## What?

Adds the following emotes to tracker:

- `:party-blob:`
- `:blobsob:`
- `:blobtoiletspin:`
- `:blobsad:`
- `:blob-spin:`
- `:blob-go:`
- `:blob_excited:`
- `:blobeyes:`
- `:blobfearful:`

(Inconsistent) names are taken from Slack so you can copy-paste from it.

## Why??

It's iconic.

## Potential Problems

- Essentially has to scan the whole DOM: I've made it as efficient as I know how to with JQuery, and it only runs after the whole page has rendered and the rest of our JS has loaded, but it's still not preferable.
- Relies on external images: They could be replaced with self-hosted images, but that felt excessive. If an image fails to load, it will be replaced by the no-image icon and the original text.
- Not useful: People seem to like it.
- Visual clutter: yes