### PR TITLE
Add foreign key constraint and relationship checks from timecard_entry to eventdate

### DIFF
--- a/app/models/timecard_entry.rb
+++ b/app/models/timecard_entry.rb
@@ -1,12 +1,12 @@
 class TimecardEntry < ApplicationRecord
   belongs_to :member
-  belongs_to :eventdate
+  belongs_to :eventdate, required: true
   belongs_to :timecard
 
   extend Enumerize
   enumerize :eventpart, in: ["call", "show", "strike"], default: "show"
 
-  validates_presence_of :member_id, :eventdate_id, :hours, :eventpart
+  validates_presence_of :eventdate, :member_id, :eventdate_id, :hours, :eventpart
   validates_numericality_of :hours, :less_than_or_equal_to => 37.5, :greater_than => 0
   validates_associated :member
   validates_inclusion_of :timecard, :in => ->(t){Timecard.valid_timecards}, :message => 'is not a current timecard', :allow_nil => true

--- a/db/migrate/20231113195629_add_eventdate_fk_to_timecards.rb
+++ b/db/migrate/20231113195629_add_eventdate_fk_to_timecards.rb
@@ -1,0 +1,10 @@
+class AddEventdateFkToTimecards < ActiveRecord::Migration[6.1]
+  def up
+    change_column :timecard_entries, :eventdate_id, :bigint
+    add_foreign_key :timecard_entries, :eventdates
+  end
+  def down
+    remove_foreign_key :timecard_entries, :eventdates
+    change_column :timecard_entries, :eventdate_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_01_123836) do
+ActiveRecord::Schema.define(version: 2023_11_13_195629) do
 
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", limit: 255, null: false
@@ -346,7 +346,7 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
   create_table "timecard_entries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "member_id"
     t.float "hours"
-    t.integer "eventdate_id"
+    t.bigint "eventdate_id"
     t.integer "timecard_id"
     t.float "payrate"
     t.datetime "created_at"
@@ -369,4 +369,5 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "timecard_entries", "eventdates"
 end


### PR DESCRIPTION
Prevent inconsistency when eventdates are deleted by enforcing that timecard entries must reference a valid eventdate.

This commit alone does not update the UI in response to this change. At minimum, the delete eventdate button should be disabled if there is at least one timecard.