### PR TITLE
Clarify error messages

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -221,7 +221,7 @@ class Event < ActiveRecord::Base
 
     def eventdate_valid?
       if representative_date < Account.magic_date
-       errors.add(:representative_date, "Requested date out of range")
+       errors.add(:representative_date, "Requested date is before the current academic year")
       end
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -221,7 +221,7 @@ class Event < ActiveRecord::Base
 
     def eventdate_valid?
       if representative_date < Account.magic_date
-       errors.add(:representative_date, "Requested date is before the current academic year")
+       errors.add(:representative_date, "Requested date cannot be before the current academic year")
       end
     end
 

--- a/app/models/event_role_application.rb
+++ b/app/models/event_role_application.rb
@@ -32,6 +32,6 @@ class EventRoleApplication < ApplicationRecord
 
   private
     def event_role_is_appliable
-      errors.add(:event_role, "is not appliable") unless event_role.appliable
+      errors.add(:event_role, "is not open to applications") unless event_role.appliable
     end
 end

--- a/app/models/timecard_entry.rb
+++ b/app/models/timecard_entry.rb
@@ -15,7 +15,7 @@ class TimecardEntry < ApplicationRecord
 
   private
     def eventdate_in_range
-      errors.add(:eventdate, 'is not in this timecard's time range') unless timecard.nil? or timecard.valid_eventdates.include? eventdate
+      errors.add(:eventdate, 'is not in this timecard\'s time range') unless timecard.nil? or timecard.valid_eventdates.include? eventdate
     end
 
     def check_submitted

--- a/app/models/timecard_entry.rb
+++ b/app/models/timecard_entry.rb
@@ -15,7 +15,7 @@ class TimecardEntry < ApplicationRecord
 
   private
     def eventdate_in_range
-      errors.add(:eventdate, 'is invalid') unless timecard.nil? or timecard.valid_eventdates.include? eventdate
+      errors.add(:eventdate, 'is not in this timecard's time range') unless timecard.nil? or timecard.valid_eventdates.include? eventdate
     end
 
     def check_submitted


### PR DESCRIPTION
Some of the error messages rely on knowledge of names internal to tracker or are generally unclear.