### PR TITLE
Rename/refactor in models for clarity

### DIFF
--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -70,7 +70,7 @@ class MembersController < ApplicationController
     @member.password_confirmation = password
     
     if @member.save
-      if not @member.andrew?
+      if not @member.andrew_email?
         raw_token, hashed_token = Devise.token_generator.generate(Member, :reset_password_token)
         @member.reset_password_token = hashed_token
         @member.reset_password_sent_at = Time.now.utc

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -150,9 +150,9 @@ module EventsHelper
       return link_to("you?", new_application_url(er.event, event_role_id: er.id, format: :js), :remote => true) unless hover
       "you?" if hover
     elsif !hover and current_member
-      er.assigned_to use_display_name: true
+      er.assigned_to_name use_display_name: true
     else
-      er.assigned_to
+      er.assigned_to_name
     end
   end
   

--- a/app/mailers/event_role_application_mailer.rb
+++ b/app/mailers/event_role_application_mailer.rb
@@ -4,7 +4,7 @@ class EventRoleApplicationMailer < ActionMailer::Base
     @application = application
     @notes = notes
 
-    mail to: application.superior_email, from: "no-reply@abtech.andrew.cmu.edu", subject: "Application for #{application.event_role.description} #{application.event_role.role} from #{application.member.display_name}"
+    mail to: application.superior_emails, from: "no-reply@abtech.andrew.cmu.edu", subject: "Application for #{application.event_role.description} #{application.event_role.role} from #{application.member.display_name}"
   end
   
   def accept(application)
@@ -16,6 +16,6 @@ class EventRoleApplicationMailer < ActionMailer::Base
   def withdraw(application)
     @application = application
 
-    mail to: application.superior_email, from: "no-reply@abtech.andrew.cmu.edu", subject: "Application withdrawn for #{application.event_role.description} #{application.event_role.role} from #{application.member.display_name}"
+    mail to: application.superior_emails, from: "no-reply@abtech.andrew.cmu.edu", subject: "Application withdrawn for #{application.event_role.description} #{application.event_role.role} from #{application.member.display_name}"
   end
 end

--- a/app/models/current_academic_year.rb
+++ b/app/models/current_academic_year.rb
@@ -1,6 +1,6 @@
-class Account
+class CurrentAcademicYear
 
-  def self.magic_date
+  def self.start_date
     if Date.today.month < 7
       (Date.today.year - 1).to_s + '-07-01'
     else
@@ -8,7 +8,7 @@ class Account
     end
   end
   
-  def self.future_magic_date
+  def self.end_date
     if Date.today.month < 7
       Date.today.year.to_s + '-07-01'
     else

--- a/app/models/equipment_profile.rb
+++ b/app/models/equipment_profile.rb
@@ -12,15 +12,15 @@ class EquipmentProfile < ApplicationRecord
   before_validation :null_subcategory
   
   def full_category
-    if subcategory
-      "#{category} - #{subcategory}"
+    if self.subcategory
+      "#{self.category} - #{self.subcategory}"
     else
-      category
+      self.category
     end
   end
   
   private
     def null_subcategory
-      subcategory = nil if subcategory.blank?
+      self.subcategory = nil if self.subcategory.blank?
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -71,7 +71,7 @@ class Event < ActiveRecord::Base
   # validate :eventdate_valid?
   validate :textable_social_valid?
   
-  scope :current_year, -> { where("representative_date >= ? or last_representative_date > ?", Account.magic_date, Account.magic_date) }
+  scope :current_year, -> { where("representative_date >= ? or last_representative_date > ?", CurrentAcademicYear.start_date, CurrentAcademicYear.start_date) }
 
   ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql, :deltas])  # associated via eventdate
 
@@ -158,7 +158,7 @@ class Event < ActiveRecord::Base
     # a part of both years (i.e. Precollege). Otherwise Tracker does not allow
     # certain functions (like invoicing) for the now previous year's event. So,
     # we considered an event by start and end.
-    (representative_date >= Account.magic_date) or (self.last_representative_date > Account.magic_date)
+    (representative_date >= CurrentAcademicYear.start_date) or (self.last_representative_date > CurrentAcademicYear.start_date)
   end
     
   private
@@ -220,7 +220,7 @@ class Event < ActiveRecord::Base
     end
 
     def eventdate_valid?
-      if representative_date < Account.magic_date
+      if representative_date < CurrentAcademicYear.start_date
        errors.add(:representative_date, "Requested date out of range")
       end
     end

--- a/app/models/event_role.rb
+++ b/app/models/event_role.rb
@@ -107,10 +107,10 @@ class EventRole < ApplicationRecord
   end
 
   def to_s
-    role + ": " + assigned_to
+    role + ": " + assigned_to_name
   end
   
-  def assigned_to(options = {})
+  def assigned_to_name(options = {})
     if assigned?
       if options[:use_display_name]
         member.display_name
@@ -122,16 +122,13 @@ class EventRole < ApplicationRecord
     end
   end
   
-  def sort_index 
-    Roles_All.each_index { |role_index| return role_index if Roles_All[role_index] == role }
-    return -1 
+  def sort_index
+    Roles_All.index self.role
   end
 
   # define the natural sorting order
-  def <=> (role)
-    return 1 if sort_index < 0
-    return -1 if role.sort_index < 0
-    return sort_index <=> role.sort_index   
+  def <=> (other_role)
+    sort_index <=> other_role.sort_index
   end
   
   def assistants

--- a/app/models/event_role_application.rb
+++ b/app/models/event_role_application.rb
@@ -5,27 +5,27 @@ class EventRoleApplication < ApplicationRecord
   validates_presence_of :event_role, :member
   validate :event_role_is_appliable
 
-  def superior
+  def superiors
     position = event_role.superior
     unless position.nil?
       sup = event_role.roleable.event_roles.where(role: position).where.not(member: nil)
       return sup.map(&:member) unless sup.empty?
     end
 
-    sup = event_role.roleable.tic_and_stic_only
-    return sup unless sup.empty?
+    # If there are no members with a superior role
+    # TiC is next in line
 
-    []
+    event_role.roleable.tic_and_stic_only
   end
 
-  def superior_name
-    sup = superior
+  def superior_names
+    sup = superiors
     return sup.map(&:display_name) unless sup.empty?
     ["the Head of Tech"]
   end
 
-  def superior_email
-    sup = superior
+  def superior_emails
+    sup = superiors
     return sup.map(&:email) unless sup.empty?
     ["abtech@andrew.cmu.edu"]
   end

--- a/app/models/invoice_line.rb
+++ b/app/models/invoice_line.rb
@@ -16,9 +16,11 @@ class InvoiceLine < ApplicationRecord
     price * quantity
   end
 
-  def <=> (il)
-    return 1 if Invoice_Categories.find_index(category).nil?
-    return -1 if Invoice_Categories.find_index(il.category).nil?
-    return Invoice_Categories.find_index(category) <=> Invoice_Categories.find_index(il.category)
+  def sort_key
+    Invoice_Categories.find_index(category)
+  end
+
+  def <=> (other)
+    sort_key <=> other.sort_key
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -79,7 +79,7 @@ class Member < ApplicationRecord
     @ability ||= Ability.new(self)
   end
   
-  def andrew?
+  def andrew_email?
     email.end_with? "@andrew.cmu.edu"
   end
 end

--- a/app/models/timecard.rb
+++ b/app/models/timecard.rb
@@ -16,7 +16,7 @@ class Timecard < ApplicationRecord
 
   def self.valid_eventdates
     timecards = self.valid_timecards
-    return Eventdate.where(["startdate >= ? AND events.billable = ?", Account.magic_date, true]).includes(:event).references(:event).sort_by{|ed| ed.event.title} if timecards.size == 0
+    return Eventdate.where(["startdate >= ? AND events.billable = ?", CurrentAcademicYear.start_date, true]).includes(:event).references(:event).sort_by{|ed| ed.event.title} if timecards.size == 0
     start_date, end_date = timecards.inject([nil,nil]) do |pair, timecard|
       [
         ((pair[0].nil? or timecard.start_date < pair[0]) ? timecard.start_date : pair[0]), 

--- a/app/models/timecard_entry.rb
+++ b/app/models/timecard_entry.rb
@@ -25,7 +25,11 @@ class TimecardEntry < ApplicationRecord
   public
     def gross_amount
       #TODO: I think it's a bug that payrate is not mandatory.
-      (payrate and hours*payrate) or hours*member.payrate
+      if payrate
+        hours*payrate
+      else
+        hours*member.payrate
+      end
     end
 
     def eventdate_id_and_eventpart

--- a/app/views/event_role_applications/_new.html.erb
+++ b/app/views/event_role_applications/_new.html.erb
@@ -1,6 +1,6 @@
 <div id="new-event-role-application">
   <%= form_for application, url: applications_path(application.event_role.event) do |builder| %>
-    Interested in being <%= application.event_role.role %> for <%= application.event_role.description %>? This form will send an email to <%= application.superior_name.to_sentence %> letting them know of your interest.
+    Interested in being <%= application.event_role.role %> for <%= application.event_role.description %>? This form will send an email to <%= application.superior_names.to_sentence %> letting them know of your interest.
     <p><b>Any questions or comments?</b><br/><%= text_area_tag :notes, nil, class: "notes", rows: 6, maxlength: 512 %></p>
     <%= builder.hidden_field :event_role_id %>
     <%= builder.hidden_field :member_id %>

--- a/app/views/events/_event_role_fields.html.erb
+++ b/app/views/events/_event_role_fields.html.erb
@@ -11,11 +11,11 @@
     <td><%= link_to_remove_fields image_tag("cross.png"), f, f.object.new_record? %></td>
   <% elsif f.object.member == current_member %>
     <td><%= f.object.role %></td>
-    <td><%= f.object.assigned_to use_display_name: true %></td>
+    <td><%= f.object.assigned_to_name use_display_name: true %></td>
     <td></td>
     <td><%= link_to_remove_fields image_tag("cross.png"), f %></td>
   <% else %>
     <td><%= f.object.role %></td>
-    <td><%= f.object.assigned_to use_display_name: true %></td>
+    <td><%= f.object.assigned_to_name use_display_name: true %></td>
   <% end %>
 </tr>

--- a/db/migrate/20140114010016_fix_timezones.rb
+++ b/db/migrate/20140114010016_fix_timezones.rb
@@ -1,6 +1,6 @@
 class FixTimezones < ActiveRecord::Migration
   def up
-    Account.all.each do |account|
+    CurrentAcademicYear.all.each do |account|
       account.update_column(:created_at, account.created_at - account.created_at.utc_offset) if account.created_at
       account.update_column(:updated_at, account.updated_at - account.updated_at.utc_offset) if account.updated_at
     end
@@ -121,7 +121,7 @@ class FixTimezones < ActiveRecord::Migration
   end
   
   def down
-    Account.all.each do |account|
+    CurrentAcademicYear.all.each do |account|
       account.update_column(:created_at, account.created_at + account.created_at.utc_offset) if account.created_at
       account.update_column(:updated_at, account.updated_at + account.updated_at.utc_offset) if account.updated_at
     end

--- a/db/migrate/20150221221612_convert_tables_to_unicode.rb
+++ b/db/migrate/20150221221612_convert_tables_to_unicode.rb
@@ -2,7 +2,7 @@ class ConvertTablesToUnicode < ActiveRecord::Migration
   def up
     execute "ALTER DATABASE " + ActiveRecord::Base.connection.current_database + " CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
     
-    models = [Account, Attachment, Blackout, Comment, EmailForm, Email, EquipmentCategory, EquipmentEventdate, Equipment, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, TimecardEntry, Timecard]
+    models = [CurrentAcademicYear, Attachment, Blackout, Comment, EmailForm, Email, EquipmentCategory, EquipmentEventdate, Equipment, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, TimecardEntry, Timecard]
     models.each do |m|
       tn = m.table_name
       execute "ALTER TABLE " + tn + " CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
@@ -28,7 +28,7 @@ class ConvertTablesToUnicode < ActiveRecord::Migration
   def down
     execute "ALTER DATABASE " + ActiveRecord::Base.connection.current_database + " CHARACTER SET latin1 COLLATE latin1_swedish_ci;"
     
-    models = [Account, Attachment, Blackout, Comment, EmailForm, Email, EquipmentCategory, EquipmentEventdate, Equipment, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, TimecardEntry, Timecard]
+    models = [CurrentAcademicYear, Attachment, Blackout, Comment, EmailForm, Email, EquipmentCategory, EquipmentEventdate, Equipment, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, TimecardEntry, Timecard]
     models.each do |m|
       tn = m.table_name
       execute "ALTER TABLE " + tn + " CONVERT TO CHARACTER SET latin1 COLLATE latin1_swedish_ci;"

--- a/db/migrate/20160815162731_convert_tables_to_real_unicode.rb
+++ b/db/migrate/20160815162731_convert_tables_to_real_unicode.rb
@@ -11,7 +11,7 @@ class ConvertTablesToRealUnicode < ActiveRecord::Migration[5.0]
     
     execute "ALTER DATABASE " + ActiveRecord::Base.connection.current_database + " CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
     
-    models = [Account, Attachment, Blackout, Comment, EmailForm, Email, Equipment, EventRoleApplication, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, SuperTic, TimecardEntry, Timecard]
+    models = [CurrentAcademicYear, Attachment, Blackout, Comment, EmailForm, Email, Equipment, EventRoleApplication, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, SuperTic, TimecardEntry, Timecard]
     models.each do |m|
       tn = m.table_name
       execute "ALTER TABLE " + tn + " CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;"
@@ -49,7 +49,7 @@ class ConvertTablesToRealUnicode < ActiveRecord::Migration[5.0]
   def down
     execute "ALTER DATABASE " + ActiveRecord::Base.connection.current_database + " CHARACTER SET utf8 COLLATE utf8_unicode_ci;"
     
-    models = [Account, Attachment, Blackout, Comment, EmailForm, Email, Equipment, EventRoleApplication, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, SuperTic, TimecardEntry, Timecard]
+    models = [CurrentAcademicYear, Attachment, Blackout, Comment, EmailForm, Email, Equipment, EventRoleApplication, EventRole, Event, Eventdate, InvoiceItem, InvoiceLine, Invoice, Journal, Location, Member, Organization, SuperTic, TimecardEntry, Timecard]
     models.each do |m|
       tn = m.table_name
       execute "ALTER TABLE " + tn + " CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci;"


### PR DESCRIPTION
There are a number of parts of tracker that are ambiguous, retain irrelevant names, or are written in difficult-to-parse ways. For example, the `Account.magic_date` method, which is actually the start of the current academic year as a string. This PR aims to make minimal changes to restore some clarity, intending to avoid opinionated rewrites or structural changes.

Each commit is a change to a separate model file, in order to isolate the effects that the change has on other files. 