### PR TITLE
Resolve #439 ability to cancel individual event date

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -81,6 +81,12 @@ table.eventslist td:first-child {
 }
 
 /* row colors */
+/*
+All of these are event statuses,
+except for this_date_cancelled which can
+only come from eventdate.status for a
+cancelled eventdate.
+ */
 table.eventslist tr.event_confirmed { background: #E2F2E2; }
 table.eventslist tr.event_confirmed > td:first-child { background: #00FF00; font-size: 5px; }
 table.eventslist tr.billing_pending { background: #E1EAEF; }
@@ -90,6 +96,9 @@ table.eventslist tr.event_completed > td:first-child { background: #00A4FF; font
 table.eventslist tr.event_cancelled { background: #F9F9F9; color: #AAAAAA; }
 table.eventslist tr.event_cancelled > td:first-child { background: #ECECEC; font-size: 5px; }
 table.eventslist tr.event_cancelled a { color: #9999FF; }
+table.eventslist tr.this_date_cancelled { background: #F9F9F9; color: #AAAAAA; }
+table.eventslist tr.this_date_cancelled > td:first-child { background: #ECECEC; font-size: 5px; }
+table.eventslist tr.this_date_cancelled a { color: #9999FF; }
 table.eventslist tr.quote_sent,
 table.eventslist tr.details_requested { background: #F7F7D3; }
 table.eventslist tr.quote_sent > td:first-child,
@@ -191,6 +200,10 @@ table.eventslist .ticless {
   border-right: 1px solid #ccc;
 }
 
+#event-schedule table.this_date_cancelled {
+  color: #AAAAAA;
+}
+
 #event-schedule table th {
   font-weight: bold;
   background-color: #f7f7f7;
@@ -214,7 +227,6 @@ table.eventslist .ticless {
 }
 
 #event-schedule td.es-time {
-  color: #222;
   white-space: nowrap;
 }
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -173,7 +173,7 @@ class EventsController < ApplicationController
       :textable, :textable_social, :publish, :contact_name, :contactemail, :contact_phone, :price_quote, :notes,
       :eventdates_attributes =>
         [:id, :_destroy, :startdate, :description, :enddate, :calldate, :strikedate, :calltype, :striketype,
-        :billable_call, :billable_show, :billable_strike,
+        :billable_call, :billable_show, :billable_strike, :cancelled,
         :email_description, :notes, {:location_ids => []}, {:equipment_profile_ids => []},
         {:event_roles_attributes => [:id, :role, :member_id, :appliable, :_destroy]}],
       :attachments_attributes => [:attachment, :name, :id, :_destroy],
@@ -250,6 +250,7 @@ class EventsController < ApplicationController
               p[:eventdates_attributes][key].delete(:billable_call)
               p[:eventdates_attributes][key].delete(:billable_show)
               p[:eventdates_attributes][key].delete(:billable_strike)
+              p[:eventdates_attributes][key].delete(:cancelled)
             
               assistants = red.run_positions_for(current_member).flat_map(&:assistants)
               p[:eventdates_attributes][key][:event_roles_attributes].select! do |_,er|

--- a/app/models/eventdate.rb
+++ b/app/models/eventdate.rb
@@ -12,6 +12,7 @@ class Eventdate < ApplicationRecord
   accepts_nested_attributes_for :event_roles, :allow_destroy => true
 
   validates_presence_of :startdate, :enddate, :description, :locations, :calltype, :striketype
+  validates_inclusion_of :cancelled, :in => [true, false]
   validates_associated :locations, :equipment_profile
   validate :dates, :validate_call, :validate_strike
 

--- a/app/models/eventdate.rb
+++ b/app/models/eventdate.rb
@@ -196,6 +196,10 @@ class Eventdate < ApplicationRecord
     end
   end
 
+  def status
+    cancelled ? "This Date Cancelled" : event.status
+  end
+
   private
     def prune_roles
       self.event_roles = self.event_roles.reject { |er| er.role.blank? }

--- a/app/views/events/_eventdate_fields.html.erb
+++ b/app/views/events/_eventdate_fields.html.erb
@@ -20,6 +20,10 @@
       <dt><%= f.label :billable_strike, "Strike Billable:" %></dt>
       <dd><%= f.check_box :billable_strike %></dd>
     </dl>
+    <dl class="big-field">
+      <dt><%= f.label :cancelled, "Cancelled:" %></dt>
+      <dd><%= f.check_box :cancelled %></dd>
+    </dl>
     <dl>
       <dt><%= f.label :calldate, "Call:" %></dt>
       <dd>

--- a/app/views/events/_run.html.erb
+++ b/app/views/events/_run.html.erb
@@ -1,5 +1,5 @@
 <% run.each_with_index do |eventdate, run_i| %>
-  <tr class="<%= eventdate.event.status.delete(' ').underscore %>">
+  <tr class="<%= eventdate.status.delete(' ').underscore %>">
     <td>&nbsp;</td>
     <td>
       <% if eventdate.startdate.year == Date.today.year %>
@@ -8,7 +8,7 @@
         <%= eventdate.startdate.strftime("%A, %B %d, %Y") %>
       <% end %><br />
       <% if can? :read, Event %>
-        <small class="published">(<%= eventdate.event.status.downcase %><%= eventdate.event.rental ? ", rental" : "" %><%= !eventdate.event.publish ? ",<br/><b>not published</b>".html_safe : "" %>)</small>
+        <small class="published">(<%= eventdate.status.downcase %><%= eventdate.event.rental ? ", rental" : "" %><%= !eventdate.event.publish ? ",<br/><b>not published</b>".html_safe : "" %>)</small>
       <% end %>
     </td>
     <td>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,9 +6,9 @@
   
     <div id="event-schedule">
       <% @event.eventdates.each do |eventdate| %>
-        <table>
+        <table<% if eventdate.cancelled %> class="this_date_cancelled"<% end %>>
           <tr>
-            <th colspan=4><%= eventdate.description %></th>
+            <th colspan=4><%= eventdate.description %><% if eventdate.cancelled %> (Cancelled)<% end %></th>
           </tr>
           <% eventdate.times.each do |time| %>
             <tr>

--- a/db/migrate/20231127150626_cancel_eventdates.rb
+++ b/db/migrate/20231127150626_cancel_eventdates.rb
@@ -1,0 +1,9 @@
+class CancelEventdates < ActiveRecord::Migration[6.1]
+  def up
+    add_column :eventdates, :cancelled, :boolean, default: false
+  end
+
+  def down
+    remove_column :eventdates, :cancelled
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_01_123836) do
+ActiveRecord::Schema.define(version: 2023_11_27_150626) do
 
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", limit: 255, null: false
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
     t.boolean "billable_call", default: true
     t.boolean "billable_show", default: true
     t.boolean "billable_strike", default: true
+    t.boolean "cancelled", default: false
     t.index ["enddate"], name: "eventdates_enddate_index"
     t.index ["event_id"], name: "eventdates_event_id_index"
     t.index ["startdate"], name: "eventdates_startdate_index"
@@ -346,7 +347,7 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
   create_table "timecard_entries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "member_id"
     t.float "hours"
-    t.integer "eventdate_id"
+    t.bigint "eventdate_id"
     t.integer "timecard_id"
     t.float "payrate"
     t.datetime "created_at"
@@ -369,4 +370,5 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "timecard_entries", "eventdates"
 end


### PR DESCRIPTION
Adds a `cancelled` option to eventdates, and makes cancelled dates mirror cancelled event styles in the event list and when editing an event.

As of 2a092ff8 a date marked `cancelled` can still be billed for if marked `show billable` or similar. This does not reflect how events work (cannot bill for cancelled events even if they are marked billable), but may be necessary for edge cases such as an event getting cancelled after an early setup but before the show.