### PR TITLE
Resolve #439 by adding eventdate statuses

### DIFF
--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -81,6 +81,12 @@ table.eventslist td:first-child {
 }
 
 /* row colors */
+table.eventslist tr.date_completed { background: #E1EAEF; }
+table.eventslist tr.date_completed > td:first-child { background: #00A4FF; font-size: 5px; }
+table.eventslist tr.date_cancelled { background: #F9F9F9; color: #AAAAAA; }
+table.eventslist tr.date_cancelled > td:first-child { background: #ECECEC; font-size: 5px; }
+table.eventslist tr.date_cancelled a { color: #9999FF; }
+
 table.eventslist tr.event_confirmed { background: #E2F2E2; }
 table.eventslist tr.event_confirmed > td:first-child { background: #00FF00; font-size: 5px; }
 table.eventslist tr.billing_pending { background: #E1EAEF; }
@@ -183,6 +189,23 @@ table.eventslist .ticless {
   }
 }
 
+/* Event schedule */
+
+#event-schedule table.date_completed * { background: #E1EAEF; }
+#event-schedule table.date_completed tr:first-child * { background: #00A4FF; }
+
+#event-schedule table.date_cancelled * { background: #F9F9F9; color: #AAAAAA; }
+#event-schedule table.date_cancelled * { background: #ECECEC; }
+#event-schedule table.date_cancelled tr:first-child a { color: #9999FF; }
+
+//table.eventslist tr.date_completed { background: #E1EAEF; }
+//table.eventslist tr.date_completed > td:first-child { background: #00A4FF; font-size: 5px; }
+//
+//table.eventslist tr.date_cancelled { background: #F9F9F9; color: #AAAAAA; }
+//table.eventslist tr.date_cancelled { background: #F9F9F9; color: #AAAAAA; }
+//table.eventslist tr.date_cancelled > td:first-child { background: #ECECEC; font-size: 5px; }
+//table.eventslist tr.date_cancelled a { color: #9999FF; }
+
 #event-schedule table {
   width: 100%;
   margin-bottom: 1em;
@@ -214,7 +237,6 @@ table.eventslist .ticless {
 }
 
 #event-schedule td.es-time {
-  color: #222;
   white-space: nowrap;
 }
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -142,7 +142,7 @@ class EventsController < ApplicationController
       :textable, :textable_social, :publish, :contact_name, :contactemail, :contact_phone, :price_quote, :notes, :created_email,
       :eventdates_attributes =>
         [:startdate, :description, :enddate, :calldate, :strikedate, :calltype, :striketype, :email_description, :notes,
-        :billable_call, :billable_show, :billable_strike,
+        :billable_call, :billable_show, :billable_strike, :status,
         {:location_ids => []}, {:equipment_profile_ids => []}, {:event_roles_attributes => [:role, :member_id, :appliable]}],
       :event_roles_attributes => [:role, :member_id, :appliable],
       :attachments_attributes => [:attachment, :name],
@@ -173,7 +173,7 @@ class EventsController < ApplicationController
       :textable, :textable_social, :publish, :contact_name, :contactemail, :contact_phone, :price_quote, :notes,
       :eventdates_attributes =>
         [:id, :_destroy, :startdate, :description, :enddate, :calldate, :strikedate, :calltype, :striketype,
-        :billable_call, :billable_show, :billable_strike,
+        :billable_call, :billable_show, :billable_strike, :status,
         :email_description, :notes, {:location_ids => []}, {:equipment_profile_ids => []},
         {:event_roles_attributes => [:id, :role, :member_id, :appliable, :_destroy]}],
       :attachments_attributes => [:attachment, :name, :id, :_destroy],
@@ -250,6 +250,7 @@ class EventsController < ApplicationController
               p[:eventdates_attributes][key].delete(:billable_call)
               p[:eventdates_attributes][key].delete(:billable_show)
               p[:eventdates_attributes][key].delete(:billable_strike)
+              p[:eventdates_attributes][key].delete(:status)
             
               assistants = red.run_positions_for(current_member).flat_map(&:assistants)
               p[:eventdates_attributes][key][:event_roles_attributes].select! do |_,er|

--- a/app/models/eventdate.rb
+++ b/app/models/eventdate.rb
@@ -207,6 +207,31 @@ class Eventdate < ApplicationRecord
     end
   end
 
+  def cancelled?
+    status == Eventdate_Status_Cancelled
+  end
+
+  def completed?
+    status == Eventdate_Status_Completed
+  end
+
+  def incomplete?
+    status == Eventdate_Status_Incomplete
+  end
+
+  def status_hint
+    status unless incomplete?
+  end
+
+  def css_class
+    status.delete(' ').underscore unless incomplete?
+  end
+
+  def row_css_class
+    return status.delete(' ').underscore unless incomplete?
+    event.status.delete(' ').underscore
+  end
+
   private
     def prune_roles
       self.event_roles = self.event_roles.reject { |er| er.role.blank? }

--- a/app/models/eventdate.rb
+++ b/app/models/eventdate.rb
@@ -9,9 +9,21 @@ class Eventdate < ApplicationRecord
     include_association [:event_roles, :locations, :equipment_profile]
   end
 
+  Eventdate_Status_Incomplete   = "Date Incomplete"
+  Eventdate_Status_Completed    = "Date Completed"
+  Eventdate_Status_Cancelled    = "Date Cancelled"
+
+  Eventdate_Status_Group_All = [
+    Eventdate_Status_Incomplete,
+    Eventdate_Status_Completed,
+    Eventdate_Status_Cancelled,
+  ]
+
+
   accepts_nested_attributes_for :event_roles, :allow_destroy => true
 
-  validates_presence_of :startdate, :enddate, :description, :locations, :calltype, :striketype
+  validates_presence_of :startdate, :enddate, :description, :locations, :calltype, :striketype, :status
+  validates_inclusion_of    :status, :in => Eventdate_Status_Group_All
   validates_associated :locations, :equipment_profile
   validate :dates, :validate_call, :validate_strike
 

--- a/app/views/events/_eventdate_fields.html.erb
+++ b/app/views/events/_eventdate_fields.html.erb
@@ -8,6 +8,10 @@
       <dt><%= f.label :email_description, "Weekly Email Description:" %></dt>
       <dd><%= f.text_area :email_description %></dd>
     </dl>
+    <dl>
+      <dt><%= f.label :status, "Status:" %></dt>
+      <dd><%= f.select :status, Eventdate::Eventdate_Status_Group_All %></dd>
+    </dl>
     <dl class="big-field">
       <dt><%= f.label :billable_call, "Call Billable:" %></dt>
       <dd><%= f.check_box :billable_call %></dd>

--- a/app/views/events/_run.html.erb
+++ b/app/views/events/_run.html.erb
@@ -1,5 +1,5 @@
 <% run.each_with_index do |eventdate, run_i| %>
-  <tr class="<%= eventdate.event.status.delete(' ').underscore %>">
+  <tr class="<%= eventdate.row_css_class %>">
     <td>&nbsp;</td>
     <td>
       <% if eventdate.startdate.year == Date.today.year %>
@@ -8,7 +8,7 @@
         <%= eventdate.startdate.strftime("%A, %B %d, %Y") %>
       <% end %><br />
       <% if can? :read, Event %>
-        <small class="published">(<%= eventdate.event.status.downcase %><%= eventdate.event.rental ? ", rental" : "" %><%= !eventdate.event.publish ? ",<br/><b>not published</b>".html_safe : "" %>)</small>
+        <small class="published">(<%= eventdate.status_hint.downcase + ", " if eventdate.status_hint %><%= eventdate.event.status.downcase %><%= eventdate.event.rental ? ", rental" : "" %><%= !eventdate.event.publish ? ",<br/><b>not published</b>".html_safe : "" %>)</small>
       <% end %>
     </td>
     <td>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,9 +6,9 @@
   
     <div id="event-schedule">
       <% @event.eventdates.each do |eventdate| %>
-        <table>
+        <table class="<%= eventdate.css_class %>">
           <tr>
-            <th colspan=4><%= eventdate.description %></th>
+            <th colspan=4><%= eventdate.description %><%= " (" + eventdate.status_hint + ")" if eventdate.status_hint %></th>
           </tr>
           <% eventdate.times.each do |time| %>
             <tr>

--- a/db/migrate/20231127195405_eventdate_statuses.rb
+++ b/db/migrate/20231127195405_eventdate_statuses.rb
@@ -1,0 +1,9 @@
+class EventdateStatuses < ActiveRecord::Migration[6.1]
+  def up
+    add_column :eventdates, :status, :string, default: "Date Incomplete"
+  end
+
+  def down
+    remove_column :eventdates, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_01_123836) do
+ActiveRecord::Schema.define(version: 2023_11_27_195405) do
 
   create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.string "name", limit: 255, null: false
@@ -172,6 +172,7 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
     t.boolean "billable_call", default: true
     t.boolean "billable_show", default: true
     t.boolean "billable_strike", default: true
+    t.string "status", default: "Date Incomplete"
     t.index ["enddate"], name: "eventdates_enddate_index"
     t.index ["event_id"], name: "eventdates_event_id_index"
     t.index ["startdate"], name: "eventdates_startdate_index"
@@ -346,7 +347,7 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
   create_table "timecard_entries", charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "member_id"
     t.float "hours"
-    t.integer "eventdate_id"
+    t.bigint "eventdate_id"
     t.integer "timecard_id"
     t.float "payrate"
     t.datetime "created_at"
@@ -369,4 +370,5 @@ ActiveRecord::Schema.define(version: 2023_08_01_123836) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "timecard_entries", "eventdates"
 end


### PR DESCRIPTION
Resolves #439 
Supersedes #534 

This adds statuses to eventdates, so they can be marked cancelled or completed similar to events.

As of 45b6d1b4 a date marked `cancelled` can still be billed for if marked `show billable` or similar. This does not reflect how events work (cannot bill for cancelled events even if they are marked billable), but may be necessary for edge cases such as an event getting cancelled after an early setup but before the show.