### PR TITLE
fix: order member timecards chronologically

### DIFF
--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -117,7 +117,7 @@
       <td>
         <h2>Billing</h2>
         <table class="generic">
-        <% @member.timecards.each do |timecard| %>
+        <% @member.timecards.sort_by(&:billing_date).each do |timecard| %>
           <tr>
             <th>Timecard for <%= timecard.billing_date.strftime("%D") %></th>
             <td> <%= pluralize timecard.hours(@member), "hour" %>


### PR DESCRIPTION
The timecard display per member is currently unsorted and may be out-of-order. We instead enforce it to be chronological in increasing order, matching approximate previous behavior and the sort order of run positions on the same page.