### PR TITLE
Bump msgpack version from 1.4.4 to 1.4.5 to fix install issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.17.0)
-    msgpack (1.4.4)
+    msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -361,7 +361,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 3.0.6p216
+   ruby 3.0.7p220
 
 BUNDLED WITH
-   2.4.7
+   2.5.21


### PR DESCRIPTION
Running bundle install on Macos with msgpack 1.4.4 gives an error. Bumping it to 1.4.5 fixes it. Current ruby version 3.0.7 but had the same problem with 3.0.6