### PR TITLE
fix: labor hours need two decimal places

### DIFF
--- a/app/models/timecard.rb
+++ b/app/models/timecard.rb
@@ -53,7 +53,7 @@ class Timecard < ApplicationRecord
     if scope.empty?
       0
     else
-      scope.map(&:hours).reduce(&:+).round(1)
+      scope.map(&:hours).reduce(&:+).round(2)
     end
   end
 

--- a/app/views/timecards/_timecard.html.erb
+++ b/app/views/timecards/_timecard.html.erb
@@ -28,7 +28,7 @@
     <tr>
       <td><strong>Total</strong></td>
       <td></td>
-      <td><%= timecard.entries(member).map(&:hours).reduce(0.0, &:+).round(1) %></td>
+      <td><%= timecard.entries(member).map(&:hours).reduce(0.0, &:+).round(2) %></td>
       <% unless timecard.entries(member).empty? %><th></th><% end %>
     </tr>
   </tfoot>


### PR DESCRIPTION
Labor hour totals should be rounded to two decimal places, because we allow billing in quarter-hour increments: 0.25 and 0.75 should remain as such, instead of becoming 0.3 and 0.8.

![image](https://github.com/user-attachments/assets/b52a8d00-b757-464e-a46c-e11d84c7b397)


![image](https://github.com/user-attachments/assets/6608db29-a004-4ccb-a838-230bac6c5fb2)
