### PR TITLE
feat(members): add hyperlink to timecard on member show page

### DIFF
--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -125,7 +125,7 @@
         <table class="generic">
         <% @member.timecards.sort_by(&:billing_date).each do |timecard| %>
           <tr>
-            <th>Timecard for <%= timecard.billing_date.strftime("%D") %></th>
+            <th><%= link_to "Timecard for #{timecard.billing_date.strftime("%D")}", timecard_path(timecard) %></th>
             <td> <%= pluralize timecard.hours(@member), "hour" %>
            </td>
           </tr>


### PR DESCRIPTION
Solves Max issue.
<img width="431" height="219" alt="image" src="https://github.com/user-attachments/assets/836095b8-9d9d-4657-9353-8f98270202c1" />

The styling stays the same unless you hover - this seems to be an intentional design decision according to the stylesheet