### PR TITLE
feat(timecard-entries): auto-select open timecard based on selected event

### DIFF
--- a/app/helpers/timecard_entries_helper.rb
+++ b/app/helpers/timecard_entries_helper.rb
@@ -1,2 +1,15 @@
 module TimecardEntriesHelper
+  def eventdate_select_options(eventdates_and_parts)
+    eventdates_and_parts.collect do |e|
+      label = [e[:eventdate].event.title, e[:eventdate].description, TimecardEntry.eventpart.options.rassoc(e[:eventpart]).first].join(' - ')
+      value = "#{e[:eventdate].id}-#{e[:eventpart]}"
+      [label, value, {"data-startdate" => e[:eventdate].startdate.iso8601}]
+    end
+  end
+
+  def timecard_select_options(timecards)
+    timecards.map do |t|
+      [t.billing_date.strftime("%Y/%m/%d"), t.id, {"data-start" => t.start_date.iso8601, "data-end" => t.end_date.iso8601}]
+    end
+  end
 end

--- a/app/javascript/src/timecard_entries.js
+++ b/app/javascript/src/timecard_entries.js
@@ -1,2 +1,53 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
+
+$(function () {
+  var eventSelect = $('#timecard_entry_eventdate_id_and_eventpart');
+  var timecardSelect = $('#timecard_entry_timecard_id');
+  if (!eventSelect.length || !timecardSelect.length) return;
+
+  var allOptions = timecardSelect.find('option').clone();
+
+  function setMultiMode(options) {
+    timecardSelect.empty().append(options.clone()).show().prop('disabled', false);
+    $('#timecard-single-display').hide();
+    $('#timecard_id_single').prop('disabled', true);
+    $('#timecard-no-match-message').hide();
+  }
+
+  function setSingleMode(option) {
+    timecardSelect.hide().prop('disabled', true);
+    $('#timecard-single-display').text(option.text()).show();
+    $('#timecard_id_single').val(option.val()).prop('disabled', false);
+    $('#timecard-no-match-message').hide();
+  }
+
+  function setNoMatchMode() {
+    timecardSelect.empty().append(allOptions.clone()).show().prop('disabled', false);
+    $('#timecard-single-display').hide();
+    $('#timecard_id_single').prop('disabled', true);
+    $('#timecard-no-match-message').show();
+  }
+
+  function updateTimecardField() {
+    var startDate = eventSelect.find(':selected').data('startdate');
+    if (!startDate) { setMultiMode(allOptions); return; }
+
+    var eventDate = new Date(startDate);
+    var matching = allOptions.filter(function () {
+      return eventDate >= new Date($(this).data('start')) &&
+             eventDate <= new Date($(this).data('end'));
+    });
+
+    if (matching.length === 0) {
+      setNoMatchMode();
+    } else if (matching.length === 1) {
+      setSingleMode(matching.first());
+    } else {
+      setMultiMode(matching);
+    }
+  }
+
+  eventSelect.change(updateTimecardField);
+  updateTimecardField();
+});

--- a/app/views/timecard_entries/_form.html.erb
+++ b/app/views/timecard_entries/_form.html.erb
@@ -13,12 +13,12 @@
         <%= select :timecard_entry, :timecard_id, options_for_select(timecard_select_options(@timecards)) -%>
         <span id="timecard-single-display" style="display:none;"></span>
         <%= hidden_field_tag 'timecard_entry[timecard_id]', '', id: 'timecard_id_single', disabled: true %>
-        <span id="timecard-no-match-message" style="display:none;">No open timecard covers this event</span>
+        <span id="timecard-no-match-message" style="display:none;">No open timecard covers this event (this is not supposed to happen - you should probably share this in #tracker-dev)</span>
         <%- elsif @timecards.size == 1 -%>
         <%= @timecards[0].billing_date.strftime("%Y/%m/%d") -%>
         <%= hidden_field :timecard_entry, :timecard_id, :value => @timecards[0].id -%>
         <%- else -%>
-        No open timecard covers this event
+        No timecards are currently open
         <%- end %></td>
   </tr>
 </table>

--- a/app/views/timecard_entries/_form.html.erb
+++ b/app/views/timecard_entries/_form.html.erb
@@ -1,21 +1,24 @@
 <table class="generic">
   <tr>
     <td align="right" class="list"><strong>Event:</strong></td>
-    <td class="list"><%= select :timecard_entry, :eventdate_id_and_eventpart, @eventdates_and_parts.collect{|e| [e[:eventdate].event.title + ' - ' + e[:eventdate].description + ' - ' + TimecardEntry.eventpart.options.rassoc(e[:eventpart]).first, e[:eventdate].id.to_s + "-" + e[:eventpart]]} %></td>
+    <td class="list"><%= select :timecard_entry, :eventdate_id_and_eventpart, options_for_select(eventdate_select_options(@eventdates_and_parts)) %></td>
   </tr>
   <tr>
     <td align="right" class="list"><strong>Hours:</strong></td>
     <td class="list"><%= number_field :timecard_entry, :hours, step: 0.25 %></td>
   </tr>
-  <% if @timecards.size > 0 %>
   <tr>
     <td align="right" class="list"><strong>Timecard:</strong></td>
     <td class="list"><% if @timecards.size > 1 -%>
-        <%= select :timecard_entry, :timecard_id, @timecards.map{|t| [t.billing_date.strftime("%Y/%m/%d"), t.id]} -%>
-        <%- else -%>
+        <%= select :timecard_entry, :timecard_id, options_for_select(timecard_select_options(@timecards)) -%>
+        <span id="timecard-single-display" style="display:none;"></span>
+        <%= hidden_field_tag 'timecard_entry[timecard_id]', '', id: 'timecard_id_single', disabled: true %>
+        <span id="timecard-no-match-message" style="display:none;">No open timecard covers this event</span>
+        <%- elsif @timecards.size == 1 -%>
         <%= @timecards[0].billing_date.strftime("%Y/%m/%d") -%>
         <%= hidden_field :timecard_entry, :timecard_id, :value => @timecards[0].id -%>
+        <%- else -%>
+        No open timecard covers this event
         <%- end %></td>
   </tr>
-  <% end %>
 </table>


### PR DESCRIPTION
When creating a timecard entry, the timecard field now automatically filters to only show open timecards that cover the selected event's date.

  - If one timecard matches, it collapses to the same display as when there's only one open timecard
  - If multiple match, the dropdown is filtered to only the valid options
  - If none match (shouldn't happen), an error message is shown mentioning this is weird
  - If no timecards are open at all, a message says so instead of hiding the field entirely (improvement)