### PR TITLE
New invoices for events that cross academic year

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -71,9 +71,9 @@ class Event < ActiveRecord::Base
   # validate :eventdate_valid?
   validate :textable_social_valid?
   
-# TODO: Fix DB migration for last_representative_date
-#  scope :current_year, -> { where("representative_date >= ? or last_representative_date > ?", Account.magic_date, Account.magic_date) }
-  scope :current_year, -> { where("representative_date >= ?", Account.magic_date) }
+  scope :current_year, -> {
+    where("EXISTS (SELECT 1 FROM eventdates ed WHERE ed.event_id = events.id AND ed.startdate >= ?)", Account.magic_date)
+  }
 
   ThinkingSphinx::Callbacks.append(self, :behaviours => [:sql, :deltas])  # associated via eventdate
 


### PR DESCRIPTION
don't worry about it

Everything has correct semantics for events that span two academic years... except for the dropdown creating a new invoice (or editing that invoice), which uses this scope.